### PR TITLE
Feature/chargeback

### DIFF
--- a/.stopwords
+++ b/.stopwords
@@ -15,6 +15,7 @@ downloadable
 en
 ergument
 fr
+FraudServices
 GeoIP
 GeoLite
 geoname_id

--- a/Changes
+++ b/Changes
@@ -1,5 +1,26 @@
 {{$NEXT}}
 
+1.008000 2018-05-03
+
+[ENHANCEMENTS]
+
+- Added a new Model for WebService::MinFraud::Chargebacks
+- Updated WebService::MinFraud::Client to support API calls to
+   chargebacks
+  - Added chargeback subroutine
+- Updated How WebService::MinFraud::Validator works
+  - Validation for individual api end points moved to
+    WebService::MinFraud::Validator::*
+  - Added Validators for existing Fraud Services
+  - Added Validation for Chargebacks
+  - Validator now checks for the endpoint it needs to validate
+  - Validator interface preserved.
+
+[ BUGFIXES ]
+
+- Corrected Autovivification bug in WebService::MinFraud::Clinet->_fix_booleans.
+- Fixed Test exception in xt/author-basic.t
+
 1.007000 2018-04-11
 
 - Renamed the WebService::MinFraud::Client constructor argument user_id

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ version 1.007000
         license_key => 'abcdef123456',
     );
 
-    # Request HashRef must contain a 'device' key, with a value that is a
+    # For the fraud services, the request HashRef must contain a 'device' key, with a value that is a
     # HashRef containing an 'ip_address' key with a valid IPv4 or IPv6 address.
     # All other keys/values are optional; see other modules in minFraud Perl API
     # distribution for details.
@@ -39,10 +39,23 @@ version 1.007000
     my $factors = $client->factors( $request );
     say $factors->subscores->ip_tenure;
 
+    # Use the 'chargeback' method. The chargeback api does not return
+    # any content from the server.
+    
+    use Try::Tiny;
+    try { 
+      $client->chargeback( $request );
+      say 'Successfully submitted chargeback';
+    } 
+    catch { 
+      say "Error: $_";
+    };
+
 # DESCRIPTION
 
 This distribution provides an API for the
-[MaxMind minFraud Score, Insights, and Factors web services](https://dev.maxmind.com/minfraud/).
+[MaxMind minFraud Score, Insights, and Factors web services](https://dev.maxmind.com/minfraud/)
+and the [axMind minFraud Chargeback web service](https://dev/maxmind.com/minfraud/chargeback/).
 
 See [WebService::MinFraud::Client](https://metacpan.org/pod/WebService::MinFraud::Client) for details on using the web service client
 API.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ WebService::MinFraud - API for MaxMind's minFraud Score, Insights, and Factors s
 
 # VERSION
 
-version 1.007000
+version 1.007001
 
 # SYNOPSIS
 
@@ -39,19 +39,26 @@ version 1.007000
     my $factors = $client->factors( $request );
     say $factors->subscores->ip_tenure;
 
+    # For the chargeback service, the request HashRef must contain an 'ip_address' key
+    # with a valid IPv4 or IPv6 address.
+    # All other keys/values are optional; see other modules in minFraud Perl API
+    # distribution for details.
+
+    my $request = { ip_address => '24.24.24.24' };
+
     # Use the 'chargeback' method. The chargeback api does not return
     # any content from the server.
 
     my $chargeback = $client->chargeback( $request );
-    if ( $chargeback->isa('WebService::MinFraud::Model::Chargeback')) {
-       say 'Successfully submitted chargeback';
+    if ($chargeback->isa('WebService::MinFraud::Model::Chargeback')) {
+      say 'Successfully submitted chargeback';
     }
 
 # DESCRIPTION
 
 This distribution provides an API for the
 [MaxMind minFraud Score, Insights, and Factors web services](https://dev.maxmind.com/minfraud/)
-and the [axMind minFraud Chargeback web service](https://dev/maxmind.com/minfraud/chargeback/).
+and the [MaxMind minFraud Chargeback web service](https://dev/maxmind.com/minfraud/chargeback/).
 
 See [WebService::MinFraud::Client](https://metacpan.org/pod/WebService::MinFraud::Client) for details on using the web service client
 API.
@@ -94,6 +101,7 @@ Mateu Hunter <mhunter@maxmind.com>
 # CONTRIBUTORS
 
 - Andy Jack <ajack@maxmind.com>
+- Christopher Bothwell <christopher.bothwell@endurance.com>
 - Dave Rolsky <drolsky@maxmind.com>
 - Florian Ragwitz <rafl@debian.org>
 - Greg Oschwald <goschwald@maxmind.com>

--- a/README.md
+++ b/README.md
@@ -41,15 +41,11 @@ version 1.007000
 
     # Use the 'chargeback' method. The chargeback api does not return
     # any content from the server.
-    
-    use Try::Tiny;
-    try { 
-      $client->chargeback( $request );
-      say 'Successfully submitted chargeback';
-    } 
-    catch { 
-      say "Error: $_";
-    };
+
+    my $chargeback = $client->chargeback( $request );
+    if ( $chargeback->isa('WebService::MinFraud::Model::Chargeback')) {
+       say 'Successfully submitted chargeback';
+    }
 
 # DESCRIPTION
 

--- a/lib/WebService/MinFraud.pm
+++ b/lib/WebService/MinFraud.pm
@@ -47,7 +47,7 @@ __END__
   my $factors = $client->factors( $request );
   say $factors->subscores->ip_tenure;
 
-  # For the chargeback service, the request HashRef must contain an 'ip_address' key 
+  # For the chargeback service, the request HashRef must contain an 'ip_address' key
   # with a valid IPv4 or IPv6 address.
   # All other keys/values are optional; see other modules in minFraud Perl API
   # distribution for details.
@@ -56,15 +56,11 @@ __END__
 
   # Use the 'chargeback' method. The chargeback api does not return
   # any content from the server.
-    
-  use Try::Tiny;
-  try { 
-    $client->chargeback( $request );
+
+  my $chargeback = $client->chargeback( $request );
+  if ($chargeback->isa('WebService::MinFraud::Model::Chargeback')) {
     say 'Successfully submitted chargeback';
-  } 
-  catch { 
-    say "Error: $_";
-  };
+  }
 
 =head1 DESCRIPTION
 

--- a/lib/WebService/MinFraud.pm
+++ b/lib/WebService/MinFraud.pm
@@ -28,7 +28,7 @@ __END__
       license_key => 'abcdef123456',
   );
 
-  # Request HashRef must contain a 'device' key, with a value that is a
+  # For the fraud services, the request HashRef must contain a 'device' key, with a value that is a
   # HashRef containing an 'ip_address' key with a valid IPv4 or IPv6 address.
   # All other keys/values are optional; see other modules in minFraud Perl API
   # distribution for details.
@@ -47,10 +47,30 @@ __END__
   my $factors = $client->factors( $request );
   say $factors->subscores->ip_tenure;
 
+  # For the chargeback service, the request HashRef must contain an 'ip_address' key 
+  # with a valid IPv4 or IPv6 address.
+  # All other keys/values are optional; see other modules in minFraud Perl API
+  # distribution for details.
+
+  my $request = { ip_address => '24.24.24.24' };
+
+  # Use the 'chargeback' method. The chargeback api does not return
+  # any content from the server.
+    
+  use Try::Tiny;
+  try { 
+    $client->chargeback( $request );
+    say 'Successfully submitted chargeback';
+  } 
+  catch { 
+    say "Error: $_";
+  };
+
 =head1 DESCRIPTION
 
 This distribution provides an API for the
-L<MaxMind minFraud Score, Insights, and Factors web services|https://dev.maxmind.com/minfraud/>.
+L<MaxMind minFraud Score, Insights, and Factors web services|https://dev.maxmind.com/minfraud/>
+and the L<MaxMind minFraud Chargeback web service|https://dev/maxmind.com/minfraud/chargeback/>.
 
 See L<WebService::MinFraud::Client> for details on using the web service client
 API.

--- a/lib/WebService/MinFraud/Client.pm
+++ b/lib/WebService/MinFraud/Client.pm
@@ -21,6 +21,7 @@ use WebService::MinFraud::Error::WebService;
 use WebService::MinFraud::Model::Factors;
 use WebService::MinFraud::Model::Insights;
 use WebService::MinFraud::Model::Score;
+use WebService::MinFraud::Model::Chargeback;
 use WebService::MinFraud::Types
     qw( JSONObject MaxMindID MaxMindLicenseKey Str URIObject UserAgentObject );
 use WebService::MinFraud::Validator;
@@ -170,7 +171,8 @@ sub _response_for {
     $self->_validator->validate_request( $content, $path );
     my $request = HTTP::Request->new(
         'POST', $uri,
-        HTTP::Headers->new( Accept => 'application/json' ),
+        HTTP::Headers->new( Accept => 'application/json',
+            'Content-Type' => 'application/json' ),
         $self->_json->encode($content)
     );
 

--- a/lib/WebService/MinFraud/Client.pm
+++ b/lib/WebService/MinFraud/Client.pm
@@ -365,7 +365,7 @@ __END__
   my $factors = $client->factors( $request );
   say $factors->subscores->ip_tenure;
 
-  
+
   # Request HashRef must contain an 'ip_address' key containing  a valid
   # IPv4 or IPv6 address. All other keys/values are optional; see other modules
   # in minFraud Perl API distribution for details.
@@ -383,8 +383,8 @@ __END__
 =head1 DESCRIPTION
 
 This class provides a client API for the MaxMind minFraud Score, Insights
-Factors web services, and the Chargeback web service. The B<Insights> 
-service returns more data about a transaction than the B<Score> service. 
+Factors web services, and the Chargeback web service. The B<Insights>
+service returns more data about a transaction than the B<Score> service.
 See the L<API documentation|https://dev.maxmind.com/minfraud/>
 for more details.
 
@@ -527,10 +527,10 @@ All of the fraud service request methods require a device ip_address. See the
 L<API documentation for fraud services|https://dev.maxmind.com/minfraud/>
 for details on all the values that can be part of the request. Portions of the
 request hash with undefined and empty string values are automatically removed
-from the request. 
+from the request.
 
 The chargeback request method requires an ip_address. See the
-L<API documentation for changeback|https:://dev.maxmind.com/minfraud/chargeback/>
+L<API documentation for chargeback|https:://dev.maxmind.com/minfraud/chargeback/>
 for details on all the values that can be part of the request.
 
 =head2 score
@@ -550,7 +550,7 @@ L<WebService::MinFraud::Model::Factors> object.
 
 =head2 chargeback
 
-This method calls the minFraud Chargeback web service. It returns a 
+This method calls the minFraud Chargeback web service. It returns a
 L<WebService::MinFraud::Model::Chargeback> object.
 
 =head1 User-Agent HEADER

--- a/lib/WebService/MinFraud/Client.pm
+++ b/lib/WebService/MinFraud/Client.pm
@@ -171,8 +171,10 @@ sub _response_for {
     $self->_validator->validate_request( $content, $path );
     my $request = HTTP::Request->new(
         'POST', $uri,
-        HTTP::Headers->new( Accept => 'application/json',
-            'Content-Type' => 'application/json' ),
+        HTTP::Headers->new(
+            Accept         => 'application/json',
+            'Content-Type' => 'application/json'
+        ),
         $self->_json->encode($content)
     );
 

--- a/lib/WebService/MinFraud/Client.pm
+++ b/lib/WebService/MinFraud/Client.pm
@@ -365,12 +365,27 @@ __END__
   my $factors = $client->factors( $request );
   say $factors->subscores->ip_tenure;
 
+  
+  # Request HashRef must contain an 'ip_address' key containing  a valid
+  # IPv4 or IPv6 address. All other keys/values are optional; see other modules
+  # in minFraud Perl API distribution for details.
+
+  $request = { ip_address => '24.24.24.24' };
+
+  # Use the chargeback client method to submit an IP address back to Maxmind.
+  # The chargeback api does not return any content from the server.
+
+  my $chargeback = $client->chargeback( $request );
+  if ($chargeback->isa('WebService::MinFraud::Model::Chargeback')) {
+    say 'Successfully submitted chargeback';
+  }
+
 =head1 DESCRIPTION
 
-This class provides a client API for the MaxMind minFraud Score, Insights, and
-Factors web services. The B<Insights> service returns more data about a
-transaction than the B<Score> service. See the
-L<API documentation|https://dev.maxmind.com/minfraud/>
+This class provides a client API for the MaxMind minFraud Score, Insights
+Factors web services, and the Chargeback web service. The B<Insights> 
+service returns more data about a transaction than the B<Score> service. 
+See the L<API documentation|https://dev.maxmind.com/minfraud/>
 for more details.
 
 Each web service is represented by a different model class, and
@@ -501,18 +516,22 @@ described below.
 
 The request methods are passed a HashRef as the only argument. See the L</SYNOPSIS> and L<WebService::MinFraud::Example> for detailed usage examples. Some important notes regarding values passed to the minFraud web service via the Perl API are described below.
 
-=head2 device => ip_address
+=head2 device => ip_address or ip_address
 
 This must be a valid IPv4 or IPv6 address in presentation format, i.e.,
 dotted-quad notation or the IPv6 hexadecimal-colon notation.
 
 =head1 REQUEST METHODS
 
-All of the request methods require a device ip_address. See the
-L<API documentation|https://dev.maxmind.com/minfraud/>
+All of the fraud service request methods require a device ip_address. See the
+L<API documentation for fraud services|https://dev.maxmind.com/minfraud/>
 for details on all the values that can be part of the request. Portions of the
 request hash with undefined and empty string values are automatically removed
-from the request.
+from the request. 
+
+The chargeback request method requires an ip_address. See the
+L<API documentation for changeback|https:://dev.maxmind.com/minfraud/chargeback/>
+for details on all the values that can be part of the request.
 
 =head2 score
 
@@ -528,6 +547,11 @@ L<WebService::MinFraud::Model::Insights> object.
 
 This method calls the minFraud Factors web service. It returns a
 L<WebService::MinFraud::Model::Factors> object.
+
+=head2 chargeback
+
+This method calls the minFraud Chargeback web service. It returns a 
+L<WebService::MinFraud::Model::Chargeback> object.
 
 =head1 User-Agent HEADER
 

--- a/lib/WebService/MinFraud/Model/Chargeback.pm
+++ b/lib/WebService/MinFraud/Model/Chargeback.pm
@@ -22,7 +22,7 @@ __END__
       license_key => 'abcdef123456',
   );
 
-  my $request = { device => { ip_address => '24.24.24.24' } };
+  my $request = { ip_address => '24.24.24.24' } ;
   my $chargeback = $client->chargeback($request);
 
   say $chargeback->isa('WebService::MinFraud::Model::Chargeback');

--- a/lib/WebService/MinFraud/Model/Chargeback.pm
+++ b/lib/WebService/MinFraud/Model/Chargeback.pm
@@ -31,6 +31,6 @@ __END__
 
 This class provides an interface consistent with the fraud services' model interfaces.
 
-The Chargeback api will not return any content. See L<API
+The Chargeback API will not return any content. See L<API
 documentation|https://dev.maxmind.com/minfraud/chargeback/>
 for more details.

--- a/lib/WebService/MinFraud/Model/Chargeback.pm
+++ b/lib/WebService/MinFraud/Model/Chargeback.pm
@@ -1,0 +1,36 @@
+package WebService::MinFraud::Model::Chargeback;
+
+use Moo;
+use namespace::autoclean;
+
+our $VERSION = '1.007001';
+
+1;
+
+# ABSTRACT: Model class for minFraud Chargeback
+
+__END__
+
+=head1 SYNOPSIS
+
+  use 5.010;
+
+  use WebService::MinFraud::Client;
+
+  my $client = WebService::MinFraud::Client->new(
+      account_id  => 42,
+      license_key => 'abcdef123456',
+  );
+
+  my $request = { device => { ip_address => '24.24.24.24' } };
+  my $chargeback = $client->chargeback($request);
+
+  say $chargeback->isa('WebService::MinFraud::Model::Chargeback');
+
+=head1 DESCRIPTION
+
+This class provides an interface consistent with the fraud services' model interfaces.
+
+The Chargeback api will not return any content. See L<API
+documentation|https://dev.maxmind.com/minfraud/chargeback/>
+for more details.

--- a/lib/WebService/MinFraud/Validator.pm
+++ b/lib/WebService/MinFraud/Validator.pm
@@ -24,31 +24,31 @@ has _deleter => (
 
 has _validator_chargeback => (
     is      => 'lazy',
-    isa     => Object,
+    isa     => InstanceOf ['WebService::MinFraud::Validator::Chargeback'],
     builder => sub { WebService::MinFraud::Validator::Chargeback->new },
 );
 
 has _validator_score => (
     is      => 'lazy',
-    isa     => Object,
+    isa     => InstanceOf ['WebService::MinFraud::Validator::Score'],
     builder => sub { WebService::MinFraud::Validator::Score->new },
 );
 
 has _validator_insights => (
     is      => 'lazy',
-    isa     => Object,
+    isa     => InstanceOf ['WebService::MinFraud::Validator::Insights'],
     builder => sub { WebService::MinFraud::Validator::Insights->new },
 );
 
 has _validator_factors => (
     is      => 'lazy',
-    isa     => Object,
+    isa     => InstanceOf ['WebService::MinFraud::Validator::Factors'],
     builder => sub { WebService::MinFraud::Validator::Factors->new },
 );
 
 has _validator_fraud_service => (
     is      => 'lazy',
-    isa     => Object,
+    isa     => InstanceOf ['WebService::MinFraud::Validator::FraudService'],
     builder => sub { WebService::MinFraud::Validator::FraudService->new },
 );
 
@@ -103,7 +103,7 @@ __END__
 
     my $validator = WebService::MinFraud::Validator->new;
     my $request = { device => { ip_address => '24.24.24.24' } };
-    $validator->validate_request($request, 'chargeback');
+    $validator->validate_request($request, 'score'); # takes an optional 'path'
 
 =head1 DESCRIPTION
 
@@ -115,6 +115,15 @@ passed to the C<score>, C<insights>, C<factors>, or C<chargeback> methods.
 
 =head2 validate_request
 
+    my $validator = WebService::MinFraud::Validator->new;
+    my $request = { ip => '24.24.24.24' };
+    $validator->validate_request($request, 'chargeback');
+
+    $request = { device => { ip_address => '24.24.24.24'  } };
+    $validator->validate_request($request); # by default will use WebService::MinFraud::Validator::FraudService
+
 This method takes a minFraud request as a HashRef and validates it against the
-minFraud request schema. If the request HashRef fails validation, an exception
+minFraud request schema for the spcified api endpoint. A second optional argument can be used
+to specify the validator schema to use, C<socre>, C<insights>, C<factors>, C<chargeback>,
+or C<fraud_service>. If the request HashRef fails validation, an exception
 is thrown, which is a string containing all of the validation errors.

--- a/lib/WebService/MinFraud/Validator.pm
+++ b/lib/WebService/MinFraud/Validator.pm
@@ -123,7 +123,7 @@ passed to the C<score>, C<insights>, C<factors>, or C<chargeback> methods.
     $validator->validate_request($request); # by default will use WebService::MinFraud::Validator::FraudService
 
 This method takes a minFraud request as a HashRef and validates it against the
-minFraud request schema for the specified api endpoint. A second optional argument can be used
-to specify the validator schema to use, C<socre>, C<insights>, C<factors>, C<chargeback>,
+minFraud request schema for the specified API endpoint. A second optional argument can be used
+to specify the schema to use, C<socre>, C<insights>, C<factors>, C<chargeback>,
 or C<fraud_service>. If the request HashRef fails validation, an exception
 is thrown, which is a string containing all of the validation errors.

--- a/lib/WebService/MinFraud/Validator.pm
+++ b/lib/WebService/MinFraud/Validator.pm
@@ -123,7 +123,7 @@ passed to the C<score>, C<insights>, C<factors>, or C<chargeback> methods.
     $validator->validate_request($request); # by default will use WebService::MinFraud::Validator::FraudService
 
 This method takes a minFraud request as a HashRef and validates it against the
-minFraud request schema for the spcified api endpoint. A second optional argument can be used
+minFraud request schema for the specified api endpoint. A second optional argument can be used
 to specify the validator schema to use, C<socre>, C<insights>, C<factors>, C<chargeback>,
 or C<fraud_service>. If the request HashRef fails validation, an exception
 is thrown, which is a string containing all of the validation errors.

--- a/lib/WebService/MinFraud/Validator.pm
+++ b/lib/WebService/MinFraud/Validator.pm
@@ -6,17 +6,14 @@ use namespace::autoclean;
 our $VERSION = '1.007001';
 
 use Data::Delete 0.05;
-use Data::Rx;
 use Try::Tiny;
-use Types::Standard qw( HashRef InstanceOf Object );
-use WebService::MinFraud::Data::Rx::Type::CCToken;
-use WebService::MinFraud::Data::Rx::Type::CustomInputs;
-use WebService::MinFraud::Data::Rx::Type::DateTime::RFC3339;
-use WebService::MinFraud::Data::Rx::Type::Enum;
-use WebService::MinFraud::Data::Rx::Type::Hex32;
-use WebService::MinFraud::Data::Rx::Type::Hostname;
-use WebService::MinFraud::Data::Rx::Type::IPAddress;
-use WebService::MinFraud::Data::Rx::Type::WebURI;
+use Types::Standard qw( InstanceOf Object HashRef );
+
+use WebService::MinFraud::Validator::Chargeback;
+use WebService::MinFraud::Validator::Score;
+use WebService::MinFraud::Validator::Insights;
+use WebService::MinFraud::Validator::Factors;
+use WebService::MinFraud::Validator::FraudService;
 
 has _deleter => (
     is      => 'lazy',
@@ -25,351 +22,60 @@ has _deleter => (
     handles => { _delete => 'delete' },
 );
 
-has _request_schema_definition => (
-    is      => 'lazy',
-    isa     => HashRef,
-    builder => '_build_request_schema_definition',
-);
-
-has _rx => (
-    is      => 'lazy',
-    isa     => InstanceOf ['Data::Rx'],
-    builder => sub {
-        Data::Rx->new(
-            {
-                prefix => {
-                    maxmind => 'tag:maxmind.com,MAXMIND:rx/',
-                },
-                type_plugins => [
-                    qw(
-                        WebService::MinFraud::Data::Rx::Type::CCToken
-                        WebService::MinFraud::Data::Rx::Type::CustomInputs
-                        WebService::MinFraud::Data::Rx::Type::DateTime::RFC3339
-                        WebService::MinFraud::Data::Rx::Type::Enum
-                        WebService::MinFraud::Data::Rx::Type::Hex32
-                        WebService::MinFraud::Data::Rx::Type::Hostname
-                        WebService::MinFraud::Data::Rx::Type::IPAddress
-                        WebService::MinFraud::Data::Rx::Type::WebURI
-                        )
-                ],
-            },
-        );
-    },
-);
-
-has _schema => (
+has _validator_chargeback => (
     is      => 'lazy',
     isa     => Object,
+    builder => sub { WebService::MinFraud::Validator::Chargeback->new },
+);
+
+has _validator_score => (
+    is      => 'lazy',
+    isa     => Object,
+    builder => sub { WebService::MinFraud::Validator::Score->new },
+);
+
+has _validator_insights => (
+    is      => 'lazy',
+    isa     => Object,
+    builder => sub { WebService::MinFraud::Validator::Insights->new },
+);
+
+has _validator_factors => (
+    is      => 'lazy',
+    isa     => Object,
+    builder => sub { WebService::MinFraud::Validator::Factors->new },
+);
+
+has _validator_fraud_service => (
+    is      => 'lazy',
+    isa     => Object,
+    builder => sub { WebService::MinFraud::Validator::FraudService->new },
+);
+
+has _dispatch_validator => (
+    is      => 'lazy',
+    isa     => HashRef,
     builder => sub {
         my $self = shift;
-        $self->_rx->make_schema( $self->_request_schema_definition );
+        return {
+            fraud_service => sub { $self->_validator_fraud_service },
+            score         => sub { $self->_validator_score },
+            chargeback    => sub { $self->_validator_chargeback },
+            factors       => sub { $self->_validator_factors },
+            insights      => sub { $self->_validator_insights },
+        };
     },
 );
 
-sub _build_request_schema_definition {
-    return {
-        type     => '//rec',
-        required => {
-            device => {
-                type     => '//rec',
-                required => {
-                    ip_address => {
-                        type => '/maxmind/ip',
-                    },
-                },
-                optional => {
-                    user_agent      => '//str',
-                    accept_language => '//str',
-                    session_age     => '//num',
-                    session_id      => {
-                        type   => '//str',
-                        length => { min => 1, max => 255, },
-                    },
-                },
-            },
-        },
-        optional => {
-            account => {
-                type     => '//rec',
-                optional => {
-                    user_id      => '//str',
-                    username_md5 => '/maxmind/hex32',
-                },
-            },
-            billing => {
-                type     => '//rec',
-                optional => {
-                    first_name => '//str',
-                    last_name  => '//str',
-                    company    => '//str',
-                    address    => '//str',
-                    address_2  => '//str',
-                    city       => '//str',
-                    region     => {
-                        type   => '//str',
-                        length => { 'min' => 1, 'max' => 4 },
-                    },
-                    country => {
-                        type   => '//str',
-                        length => { 'min' => 2, 'max' => 2 },
-                    },
-                    postal             => '//str',
-                    phone_number       => '//str',
-                    phone_country_code => '//int',
-                },
-            },
-            credit_card => {
-                type     => '//rec',
-                optional => {
-                    avs_result => {
-                        type   => '//str',
-                        length => { 'min' => 1, 'max' => 1 },
-                    },
-                    bank_name               => '//str',
-                    bank_phone_country_code => '//int',
-                    bank_phone_number       => '//str',
-                    cvv_result              => {
-                        type   => '//str',
-                        length => { 'min' => 1, 'max' => 1 },
-                    },
-                    issuer_id_number => {
-                        type   => '//str',
-                        length => { 'min' => 6, 'max' => 6 },
-                    },
-                    last_4_digits => {
-                        type   => '//str',
-                        length => { 'min' => 4, 'max' => 4 },
-                    },
-                    token => '/maxmind/cctoken',
-                },
-            },
-            custom_inputs => {
-                type => '/maxmind/custom_inputs',
-            },
-            email => {
-                type     => '//rec',
-                optional => {
-                    address => '//str',
-                    domain  => '/maxmind/hostname',
-                },
-            },
-            event => {
-                type     => '//rec',
-                optional => {
-                    transaction_id => '//str',
-                    shop_id        => '//str',
-                    time           => '/maxmind/datetime/rfc3339',
-                    type           => {
-                        type     => '/maxmind/enum',
-                        contents => {
-                            type   => '//str',
-                            values => [
-                                'account_creation',
-                                'account_login',
-                                'email_change',
-                                'password_reset',
-                                'payout_change',
-                                'purchase',
-                                'recurring_purchase',
-                                'referral',
-                                'survey',
-                            ],
-                        },
-                    },
-                },
-            },
-            order => {
-                type     => '//rec',
-                optional => {
-                    amount   => '//num',
-                    currency => {
-                        type   => '//str',
-                        length => { 'min' => 3, 'max' => 3 },
-                    },
-                    discount_code    => '//str',
-                    affiliate_id     => '//str',
-                    subaffiliate_id  => '//str',
-                    referrer_uri     => '/maxmind/weburi',
-                    is_gift          => '//bool',
-                    has_gift_message => '//bool',
-                },
-            },
-            payment => {
-                type     => '//rec',
-                optional => {
-                    processor => {
-                        type     => '/maxmind/enum',
-                        contents => {
-                            type   => '//str',
-                            values => [
-                                'adyen',
-                                'altapay',
-                                'amazon_payments',
-                                'american_express_payment_gateway',
-                                'authorizenet',
-                                'balanced',
-                                'beanstream',
-                                'bluepay',
-                                'bluesnap',
-                                'bpoint',
-                                'braintree',
-                                'ccavenue',
-                                'ccnow',
-                                'chase_paymentech',
-                                'checkout_com',
-                                'cielo',
-                                'collector',
-                                'commdoo',
-                                'compropago',
-                                'concept_payments',
-                                'conekta',
-                                'ct_payments',
-                                'cuentadigital',
-                                'curopayments',
-                                'cybersource',
-                                'dalenys',
-                                'dalpay',
-                                'dibs',
-                                'digital_river',
-                                'ebs',
-                                'ecomm365',
-                                'elavon',
-                                'emerchantpay',
-                                'epay',
-                                'eprocessing_network',
-                                'eway',
-                                'exact',
-                                'first_data',
-                                'global_payments',
-                                'heartland',
-                                'hipay',
-                                'ingenico',
-                                'internetsecure',
-                                'intuit_quickbooks_payments',
-                                'iugu',
-                                'lemon_way',
-                                'mastercard_payment_gateway',
-                                'mercadopago',
-                                'merchant_esolutions',
-                                'mirjeh',
-                                'mollie',
-                                'moneris_solutions',
-                                'nmi',
-                                'oceanpayment',
-                                'oney',
-                                'openpaymx',
-                                'optimal_payments',
-                                'orangepay',
-                                'other',
-                                'pacnet_services',
-                                'payfast',
-                                'paygate',
-                                'paymentwall',
-                                'payone',
-                                'paypal',
-                                'payplus',
-                                'paystation',
-                                'paytrace',
-                                'paytrail',
-                                'payture',
-                                'payu',
-                                'payulatam',
-                                'payway',
-                                'payza',
-                                'pinpayments',
-                                'posconnect',
-                                'princeton_payment_solutions',
-                                'psigate',
-                                'qiwi',
-                                'quickpay',
-                                'raberil',
-                                'rede',
-                                'redpagos',
-                                'rewardspay',
-                                'sagepay',
-                                'securetrading',
-                                'simplify_commerce',
-                                'skrill',
-                                'smartcoin',
-                                'solidtrust_pay',
-                                'sps_decidir',
-                                'stripe',
-                                'telerecargas',
-                                'towah',
-                                'transact_pro',
-                                'usa_epay',
-                                'vantiv',
-                                'verepay',
-                                'vericheck',
-                                'vindicia',
-                                'virtual_card_services',
-                                'vme',
-                                'vpos',
-                                'wirecard',
-                                'worldpay',
-                            ],
-
-                        },
-                    },
-                    was_authorized => '//bool',
-                    decline_code   => '//str',
-                },
-            },
-            shipping => {
-                type     => '//rec',
-                optional => {
-                    first_name     => '//str',
-                    last_name      => '//str',
-                    company        => '//str',
-                    address        => '//str',
-                    address_2      => '//str',
-                    city           => '//str',
-                    delivery_speed => {
-                        type     => '/maxmind/enum',
-                        contents => {
-                            type   => '//str',
-                            values => [
-                                'same_day',  'overnight',
-                                'expedited', 'standard',
-                            ],
-                        },
-                    },
-                    region => {
-                        type   => '//str',
-                        length => { 'min' => 1, 'max' => 4 },
-                    },
-                    country => {
-                        type   => '//str',
-                        length => { 'min' => 2, 'max' => 2 },
-                    },
-                    postal             => '//str',
-                    phone_number       => '//str',
-                    phone_country_code => {
-                        type   => '//str',
-                        length => { 'min' => 1, 'max' => 4 },
-                    },
-                },
-            },
-            shopping_cart => {
-                type     => '//arr',
-                contents => {
-                    type     => '//rec',
-                    optional => {
-                        category => '//str',
-                        item_id  => '//str',
-                        quantity => '//int',
-                        price    => '//num',
-                    },
-                },
-            },
-        },
-    };
-}
-
 sub validate_request {
-    my ( $self, $request ) = @_;
+    my ( $self, $request, $path ) = @_;
+
+    if ( !defined $path ) {
+        $path = 'fraud_service';
+    }
+
     try {
-        $self->_schema->assert_valid($request);
+        $self->_dispatch_validator->{$path}()->assert_valid($request);
     }
     catch {
         my @error_strings = map {
@@ -397,13 +103,13 @@ __END__
 
     my $validator = WebService::MinFraud::Validator->new;
     my $request = { device => { ip_address => '24.24.24.24' } };
-    $validator->validate_request($request);
+    $validator->validate_request($request, 'chargeback');
 
 =head1 DESCRIPTION
 
 This module defines the request schema for the minFraud API. In addition, it
 provides a C<validate_request> method that is used to validate any request
-passed to the C<score>, C<insights>, or C<factors> methods.
+passed to the C<score>, C<insights>, C<factors>, or C<chargeback> methods.
 
 =head1 METHODS
 

--- a/lib/WebService/MinFraud/Validator/Base.pm
+++ b/lib/WebService/MinFraud/Validator/Base.pm
@@ -46,6 +46,6 @@ sub _build_rx_plugins {
 
 1;
 
-# ABSTRACT: Validation for the minFraud requests
+# ABSTRACT: Abstract Base Validation for the minFraud requests
 
 __END__

--- a/lib/WebService/MinFraud/Validator/Base.pm
+++ b/lib/WebService/MinFraud/Validator/Base.pm
@@ -1,0 +1,74 @@
+package WebService::MinFraud::Validator::Base;
+
+use Moo;
+use namespace::autoclean;
+
+our $VERSION = '1.007001';
+
+use Data::Delete 0.05;
+use Carp;
+use Data::Rx;
+use Try::Tiny;
+use Types::Standard qw( HashRef InstanceOf Object );
+use WebService::MinFraud::Data::Rx::Type::CCToken;
+use WebService::MinFraud::Data::Rx::Type::CustomInputs;
+use WebService::MinFraud::Data::Rx::Type::DateTime::RFC3339;
+use WebService::MinFraud::Data::Rx::Type::Enum;
+use WebService::MinFraud::Data::Rx::Type::Hex32;
+use WebService::MinFraud::Data::Rx::Type::Hostname;
+use WebService::MinFraud::Data::Rx::Type::IPAddress;
+use WebService::MinFraud::Data::Rx::Type::WebURI;
+
+has _request_schema_definition => (
+    is      => 'lazy',
+    isa     => HashRef,
+    builder => '_build_request_schema_definition',
+);
+
+has _rx => (
+    is      => 'lazy',
+    isa     => InstanceOf ['Data::Rx'],
+    builder => sub {
+        Data::Rx->new(
+            {
+                prefix => {
+                    maxmind => 'tag:maxmind.com,MAXMIND:rx/',
+                },
+                type_plugins => [
+                    qw(
+                        WebService::MinFraud::Data::Rx::Type::CCToken
+                        WebService::MinFraud::Data::Rx::Type::CustomInputs
+                        WebService::MinFraud::Data::Rx::Type::DateTime::RFC3339
+                        WebService::MinFraud::Data::Rx::Type::Enum
+                        WebService::MinFraud::Data::Rx::Type::Hex32
+                        WebService::MinFraud::Data::Rx::Type::Hostname
+                        WebService::MinFraud::Data::Rx::Type::IPAddress
+                        WebService::MinFraud::Data::Rx::Type::WebURI
+                        )
+                ],
+            },
+        );
+    },
+);
+
+has _schema => (
+    is      => 'lazy',
+    isa     => Object,
+    builder => sub {
+        my $self = shift;
+        $self->_rx->make_schema( $self->_request_schema_definition );
+    },
+    handles => {
+        assert_valid => 'assert_valid',
+    },
+);
+
+sub _build_request_schema_definition {
+    croak 'Abstract Base Class. This method is implemented in subclasses';
+}
+
+1;
+
+# ABSTRACT: Validation for the minFraud requests
+
+__END__

--- a/lib/WebService/MinFraud/Validator/Base.pm
+++ b/lib/WebService/MinFraud/Validator/Base.pm
@@ -10,14 +10,6 @@ use Carp;
 use Data::Rx;
 use Try::Tiny;
 use Types::Standard qw( HashRef InstanceOf Object );
-use WebService::MinFraud::Data::Rx::Type::CCToken;
-use WebService::MinFraud::Data::Rx::Type::CustomInputs;
-use WebService::MinFraud::Data::Rx::Type::DateTime::RFC3339;
-use WebService::MinFraud::Data::Rx::Type::Enum;
-use WebService::MinFraud::Data::Rx::Type::Hex32;
-use WebService::MinFraud::Data::Rx::Type::Hostname;
-use WebService::MinFraud::Data::Rx::Type::IPAddress;
-use WebService::MinFraud::Data::Rx::Type::WebURI;
 
 has _request_schema_definition => (
     is      => 'lazy',
@@ -28,27 +20,7 @@ has _request_schema_definition => (
 has _rx => (
     is      => 'lazy',
     isa     => InstanceOf ['Data::Rx'],
-    builder => sub {
-        Data::Rx->new(
-            {
-                prefix => {
-                    maxmind => 'tag:maxmind.com,MAXMIND:rx/',
-                },
-                type_plugins => [
-                    qw(
-                        WebService::MinFraud::Data::Rx::Type::CCToken
-                        WebService::MinFraud::Data::Rx::Type::CustomInputs
-                        WebService::MinFraud::Data::Rx::Type::DateTime::RFC3339
-                        WebService::MinFraud::Data::Rx::Type::Enum
-                        WebService::MinFraud::Data::Rx::Type::Hex32
-                        WebService::MinFraud::Data::Rx::Type::Hostname
-                        WebService::MinFraud::Data::Rx::Type::IPAddress
-                        WebService::MinFraud::Data::Rx::Type::WebURI
-                        )
-                ],
-            },
-        );
-    },
+    builder => '_build_rx_plugins',
 );
 
 has _schema => (
@@ -65,6 +37,11 @@ has _schema => (
 
 sub _build_request_schema_definition {
     croak 'Abstract Base Class. This method is implemented in subclasses';
+}
+
+sub _build_rx_plugins {
+    croak 'Abstract Base Class. This method is implemented in subclasses';
+
 }
 
 1;

--- a/lib/WebService/MinFraud/Validator/Base.pm
+++ b/lib/WebService/MinFraud/Validator/Base.pm
@@ -5,10 +5,8 @@ use namespace::autoclean;
 
 our $VERSION = '1.007001';
 
-use Data::Delete 0.05;
 use Carp;
 use Data::Rx;
-use Try::Tiny;
 use Types::Standard qw( HashRef InstanceOf Object );
 
 has _request_schema_definition => (

--- a/lib/WebService/MinFraud/Validator/Chargeback.pm
+++ b/lib/WebService/MinFraud/Validator/Chargeback.pm
@@ -50,11 +50,11 @@ sub _build_request_schema_definition {
             },
             maxmind_id => {
                 type   => '//str',
-                length => { 'min' => 1, 'max' => 8 },
+                length => { 'min' => 8, 'max' => 8 },
             },
             minfraud_id => {
                 type   => '//str',
-                length => { 'min' => 1, 'max' => 36 },
+                length => { 'min' => 36, 'max' => 36 },
             },
             transaction_id => '//str',
         },

--- a/lib/WebService/MinFraud/Validator/Chargeback.pm
+++ b/lib/WebService/MinFraud/Validator/Chargeback.pm
@@ -62,3 +62,7 @@ sub _build_request_schema_definition {
 }
 
 1;
+
+# ABSTRACT: Validation for the minFraud Chargeback
+
+__END__

--- a/lib/WebService/MinFraud/Validator/Chargeback.pm
+++ b/lib/WebService/MinFraud/Validator/Chargeback.pm
@@ -3,9 +3,28 @@ package WebService::MinFraud::Validator::Chargeback;
 use Moo;
 use namespace::autoclean;
 
+use WebService::MinFraud::Data::Rx::Type::Enum;
+use WebService::MinFraud::Data::Rx::Type::IPAddress;
+
 our $VERSION = '1.007001';
 
 extends 'WebService::MinFraud::Validator::Base';
+
+sub _build_rx_plugins {
+    Data::Rx->new(
+        {
+            prefix => {
+                maxmind => 'tag:maxmind.com,MAXMIND:rx/',
+            },
+            type_plugins => [
+                qw(
+                    WebService::MinFraud::Data::Rx::Type::Enum
+                    WebService::MinFraud::Data::Rx::Type::IPAddress
+                    )
+            ],
+        },
+    );
+}
 
 sub _build_request_schema_definition {
     return {

--- a/lib/WebService/MinFraud/Validator/Chargeback.pm
+++ b/lib/WebService/MinFraud/Validator/Chargeback.pm
@@ -1,0 +1,45 @@
+package WebService::MinFraud::Validator::Chargeback;
+
+use Moo;
+use namespace::autoclean;
+
+our $VERSION = '1.007001';
+
+extends 'WebService::MinFraud::Validator::Base';
+
+sub _build_request_schema_definition {
+    return {
+        type     => '//rec',
+        required => {
+            ip_address => {
+                type => '/maxmind/ip',
+            },
+        },
+        optional => {
+            chargeback_code => '//str',
+            tag             => {
+                type     => '/maxmind/enum',
+                contents => {
+                    type   => '//str',
+                    values => [
+                        'not_fraud',
+                        'suspected_fraud',
+                        'spam_or_abuse',
+                        'chargeback',
+                    ],
+                },
+            },
+            maxmind_id => {
+                type   => '//str',
+                length => { 'min' => 1, 'max' => 8 },
+            },
+            minfraud_id => {
+                type   => '//str',
+                length => { 'min' => 1, 'max' => 36 },
+            },
+            transaction_id => '//str',
+        },
+    };
+}
+
+1;

--- a/lib/WebService/MinFraud/Validator/Factors.pm
+++ b/lib/WebService/MinFraud/Validator/Factors.pm
@@ -1,0 +1,10 @@
+package WebService::MinFraud::Validator::Factors;
+
+use Moo;
+use namespace::autoclean;
+
+our $VERSION = '1.007001';
+
+extends 'WebService::MinFraud::Validator::FraudService';
+
+1;

--- a/lib/WebService/MinFraud/Validator/Factors.pm
+++ b/lib/WebService/MinFraud/Validator/Factors.pm
@@ -8,3 +8,7 @@ our $VERSION = '1.007001';
 extends 'WebService::MinFraud::Validator::FraudService';
 
 1;
+
+# ABSTRACT: Validation for the minFraud Factors
+
+__END__

--- a/lib/WebService/MinFraud/Validator/FraudService.pm
+++ b/lib/WebService/MinFraud/Validator/FraudService.pm
@@ -3,9 +3,40 @@ package WebService::MinFraud::Validator::FraudService;
 use Moo;
 use namespace::autoclean;
 
+use WebService::MinFraud::Data::Rx::Type::CCToken;
+use WebService::MinFraud::Data::Rx::Type::CustomInputs;
+use WebService::MinFraud::Data::Rx::Type::DateTime::RFC3339;
+use WebService::MinFraud::Data::Rx::Type::Enum;
+use WebService::MinFraud::Data::Rx::Type::Hex32;
+use WebService::MinFraud::Data::Rx::Type::Hostname;
+use WebService::MinFraud::Data::Rx::Type::IPAddress;
+use WebService::MinFraud::Data::Rx::Type::WebURI;
+
 our $VERSION = '1.007001';
 
 extends 'WebService::MinFraud::Validator::Base';
+
+sub _build_rx_plugins {
+    Data::Rx->new(
+        {
+            prefix => {
+                maxmind => 'tag:maxmind.com,MAXMIND:rx/',
+            },
+            type_plugins => [
+                qw(
+                    WebService::MinFraud::Data::Rx::Type::CCToken
+                    WebService::MinFraud::Data::Rx::Type::CustomInputs
+                    WebService::MinFraud::Data::Rx::Type::DateTime::RFC3339
+                    WebService::MinFraud::Data::Rx::Type::Enum
+                    WebService::MinFraud::Data::Rx::Type::Hex32
+                    WebService::MinFraud::Data::Rx::Type::Hostname
+                    WebService::MinFraud::Data::Rx::Type::IPAddress
+                    WebService::MinFraud::Data::Rx::Type::WebURI
+                    )
+            ],
+        },
+    );
+}
 
 sub _build_request_schema_definition {
     return {

--- a/lib/WebService/MinFraud/Validator/FraudService.pm
+++ b/lib/WebService/MinFraud/Validator/FraudService.pm
@@ -339,3 +339,7 @@ sub _build_request_schema_definition {
 }
 
 1;
+
+# ABSTRACT: Parent Validation for the minFraud FraudServices
+
+__END__

--- a/lib/WebService/MinFraud/Validator/FraudService.pm
+++ b/lib/WebService/MinFraud/Validator/FraudService.pm
@@ -1,0 +1,310 @@
+package WebService::MinFraud::Validator::FraudService;
+
+use Moo;
+use namespace::autoclean;
+
+our $VERSION = '1.007001';
+
+extends 'WebService::MinFraud::Validator::Base';
+
+sub _build_request_schema_definition {
+    return {
+        type     => '//rec',
+        required => {
+            device => {
+                type     => '//rec',
+                required => {
+                    ip_address => {
+                        type => '/maxmind/ip',
+                    },
+                },
+                optional => {
+                    user_agent      => '//str',
+                    accept_language => '//str',
+                    session_age     => '//num',
+                    session_id      => {
+                        type   => '//str',
+                        length => { min => 1, max => 255, },
+                    },
+                },
+            },
+        },
+        optional => {
+            account => {
+                type     => '//rec',
+                optional => {
+                    user_id      => '//str',
+                    username_md5 => '/maxmind/hex32',
+                },
+            },
+            billing => {
+                type     => '//rec',
+                optional => {
+                    first_name => '//str',
+                    last_name  => '//str',
+                    company    => '//str',
+                    address    => '//str',
+                    address_2  => '//str',
+                    city       => '//str',
+                    region     => {
+                        type   => '//str',
+                        length => { 'min' => 1, 'max' => 4 },
+                    },
+                    country => {
+                        type   => '//str',
+                        length => { 'min' => 2, 'max' => 2 },
+                    },
+                    postal             => '//str',
+                    phone_number       => '//str',
+                    phone_country_code => '//int',
+                },
+            },
+            credit_card => {
+                type     => '//rec',
+                optional => {
+                    avs_result => {
+                        type   => '//str',
+                        length => { 'min' => 1, 'max' => 1 },
+                    },
+                    bank_name               => '//str',
+                    bank_phone_country_code => '//int',
+                    bank_phone_number       => '//str',
+                    cvv_result              => {
+                        type   => '//str',
+                        length => { 'min' => 1, 'max' => 1 },
+                    },
+                    issuer_id_number => {
+                        type   => '//str',
+                        length => { 'min' => 6, 'max' => 6 },
+                    },
+                    last_4_digits => {
+                        type   => '//str',
+                        length => { 'min' => 4, 'max' => 4 },
+                    },
+                    token => '/maxmind/cctoken',
+                },
+            },
+            custom_inputs => {
+                type => '/maxmind/custom_inputs',
+            },
+            email => {
+                type     => '//rec',
+                optional => {
+                    address => '//str',
+                    domain  => '/maxmind/hostname',
+                },
+            },
+            event => {
+                type     => '//rec',
+                optional => {
+                    transaction_id => '//str',
+                    shop_id        => '//str',
+                    time           => '/maxmind/datetime/rfc3339',
+                    type           => {
+                        type     => '/maxmind/enum',
+                        contents => {
+                            type   => '//str',
+                            values => [
+                                'account_creation',
+                                'account_login',
+                                'email_change',
+                                'password_reset',
+                                'payout_change',
+                                'purchase',
+                                'recurring_purchase',
+                                'referral',
+                                'survey',
+                            ],
+                        },
+                    },
+                },
+            },
+            order => {
+                type     => '//rec',
+                optional => {
+                    amount   => '//num',
+                    currency => {
+                        type   => '//str',
+                        length => { 'min' => 3, 'max' => 3 },
+                    },
+                    discount_code    => '//str',
+                    affiliate_id     => '//str',
+                    subaffiliate_id  => '//str',
+                    referrer_uri     => '/maxmind/weburi',
+                    is_gift          => '//bool',
+                    has_gift_message => '//bool',
+                },
+            },
+            payment => {
+                type     => '//rec',
+                optional => {
+                    processor => {
+                        type     => '/maxmind/enum',
+                        contents => {
+                            type   => '//str',
+                            values => [
+                                'adyen',
+                                'altapay',
+                                'amazon_payments',
+                                'american_express_payment_gateway',
+                                'authorizenet',
+                                'balanced',
+                                'beanstream',
+                                'bluepay',
+                                'bluesnap',
+                                'bpoint',
+                                'braintree',
+                                'ccavenue',
+                                'ccnow',
+                                'chase_paymentech',
+                                'checkout_com',
+                                'cielo',
+                                'collector',
+                                'commdoo',
+                                'compropago',
+                                'concept_payments',
+                                'conekta',
+                                'ct_payments',
+                                'cuentadigital',
+                                'curopayments',
+                                'cybersource',
+                                'dalenys',
+                                'dalpay',
+                                'dibs',
+                                'digital_river',
+                                'ebs',
+                                'ecomm365',
+                                'elavon',
+                                'emerchantpay',
+                                'epay',
+                                'eprocessing_network',
+                                'eway',
+                                'exact',
+                                'first_data',
+                                'global_payments',
+                                'heartland',
+                                'hipay',
+                                'ingenico',
+                                'internetsecure',
+                                'intuit_quickbooks_payments',
+                                'iugu',
+                                'lemon_way',
+                                'mastercard_payment_gateway',
+                                'mercadopago',
+                                'merchant_esolutions',
+                                'mirjeh',
+                                'mollie',
+                                'moneris_solutions',
+                                'nmi',
+                                'oceanpayment',
+                                'oney',
+                                'openpaymx',
+                                'optimal_payments',
+                                'orangepay',
+                                'other',
+                                'pacnet_services',
+                                'payfast',
+                                'paygate',
+                                'paymentwall',
+                                'payone',
+                                'paypal',
+                                'payplus',
+                                'paystation',
+                                'paytrace',
+                                'paytrail',
+                                'payture',
+                                'payu',
+                                'payulatam',
+                                'payway',
+                                'payza',
+                                'pinpayments',
+                                'posconnect',
+                                'princeton_payment_solutions',
+                                'psigate',
+                                'qiwi',
+                                'quickpay',
+                                'raberil',
+                                'rede',
+                                'redpagos',
+                                'rewardspay',
+                                'sagepay',
+                                'securetrading',
+                                'simplify_commerce',
+                                'skrill',
+                                'smartcoin',
+                                'solidtrust_pay',
+                                'sps_decidir',
+                                'stripe',
+                                'telerecargas',
+                                'towah',
+                                'transact_pro',
+                                'usa_epay',
+                                'vantiv',
+                                'verepay',
+                                'vericheck',
+                                'vindicia',
+                                'virtual_card_services',
+                                'vme',
+                                'vpos',
+                                'wirecard',
+                                'worldpay',
+                            ],
+
+                        },
+                    },
+                    was_authorized => '//bool',
+                    decline_code   => '//str',
+                },
+            },
+            shipping => {
+                type     => '//rec',
+                optional => {
+                    first_name     => '//str',
+                    last_name      => '//str',
+                    company        => '//str',
+                    address        => '//str',
+                    address_2      => '//str',
+                    city           => '//str',
+                    delivery_speed => {
+                        type     => '/maxmind/enum',
+                        contents => {
+                            type   => '//str',
+                            values => [
+                                'same_day',  'overnight',
+                                'expedited', 'standard',
+                            ],
+                        },
+                    },
+                    region => {
+                        type   => '//str',
+                        length => { 'min' => 1, 'max' => 4 },
+                    },
+                    country => {
+                        type   => '//str',
+                        length => { 'min' => 2, 'max' => 2 },
+                    },
+                    postal             => '//str',
+                    phone_number       => '//str',
+                    phone_country_code => {
+                        type   => '//str',
+                        length => { 'min' => 1, 'max' => 4 },
+                    },
+                },
+            },
+            shopping_cart => {
+                type     => '//arr',
+                contents => {
+                    type     => '//rec',
+                    optional => {
+                        category => '//str',
+                        item_id  => '//str',
+                        quantity => '//int',
+                        price    => '//num',
+                    },
+                },
+            },
+        },
+    };
+}
+
+1;

--- a/lib/WebService/MinFraud/Validator/Insights.pm
+++ b/lib/WebService/MinFraud/Validator/Insights.pm
@@ -1,0 +1,10 @@
+package WebService::MinFraud::Validator::Insights;
+
+use Moo;
+use namespace::autoclean;
+
+our $VERSION = '1.007001';
+
+extends 'WebService::MinFraud::Validator::FraudService';
+
+1;

--- a/lib/WebService/MinFraud/Validator/Insights.pm
+++ b/lib/WebService/MinFraud/Validator/Insights.pm
@@ -8,3 +8,7 @@ our $VERSION = '1.007001';
 extends 'WebService::MinFraud::Validator::FraudService';
 
 1;
+
+# ABSTRACT: Validation for the minFraud Insights
+
+__END__

--- a/lib/WebService/MinFraud/Validator/Score.pm
+++ b/lib/WebService/MinFraud/Validator/Score.pm
@@ -8,3 +8,7 @@ our $VERSION = '1.007001';
 extends 'WebService::MinFraud::Validator::FraudService';
 
 1;
+
+# ABSTRACT: Validation for the minFraud Score
+
+__END__

--- a/lib/WebService/MinFraud/Validator/Score.pm
+++ b/lib/WebService/MinFraud/Validator/Score.pm
@@ -1,0 +1,10 @@
+package WebService::MinFraud::Validator::Score;
+
+use Moo;
+use namespace::autoclean;
+
+our $VERSION = '1.007001';
+
+extends 'WebService::MinFraud::Validator::FraudService';
+
+1;

--- a/t/WebService/MinFraud/Client.t
+++ b/t/WebService/MinFraud/Client.t
@@ -349,35 +349,6 @@ sub _get_service_info {
     return $service_lookup->{$service};
 }
 
-sub _run_chargeback_request {
-    my $args = shift || {};
-
-    my $request = $args->{requests} || { ip_address => '1.1.1.1' };
-
-    my $ua = Test::LWP::UserAgent->new;
-    $ua->map_response(
-        sub {
-            $_[0]->uri eq 'https://minfraud.maxmind.com/minfraud/chargeback';
-        },
-        HTTP::Response->new(
-            $args->{status_code} || '204',
-            'No Content',
-            [
-                'Content-Type' => 'application/json; charset=UTF-8'
-                    || $args->{content_type}
-            ],
-            $args->{response_content} || undef
-        )
-    );
-
-    return WebService::MinFraud::Client->new(
-        account_id  => 42,
-        license_key => 'abcdef123456',
-        ua          => $ua,
-        %{ $args->{client_args} || {} }
-    )->chargeback($request);
-}
-
 sub _uri_for {
     'https://minfraud.maxmind.com/minfraud/v2.0/' . $_[0];
 }

--- a/t/WebService/MinFraud/Client.t
+++ b/t/WebService/MinFraud/Client.t
@@ -15,77 +15,6 @@ use WebService::MinFraud::Model::Insights   ();
 use WebService::MinFraud::Model::Score      ();
 use WebService::MinFraud::Model::Chargeback ();
 
-subtest 'chargeback' => sub {
-    subtest 'test simple success' => sub {
-        my $model = _run_chargeback_request();
-
-        isa_ok(
-            $model, 'WebService::MinFraud::Model::Chargeback',
-            'expected class type'
-        );
-    };
-
-    my $service = 'chargeback';
-
-    for my $error (
-        'FRAUD_SCORE_INVALID', 'JSON_INVALID',
-        'MAXMIND_ID_INVALID',  'MINFRAUD_ID_INVALID',
-        'PARAMETER_UNKNOWN',   'IP_ADDRESS_INVALID',
-        'IP_ADDRESS_REQUIRED', 'IP_ADDRESS_RESERVED'
-    ) {
-        subtest $error => sub {
-            _test_ws_error(
-                $service,
-                {
-                    status_code => '400',
-                    response_content =>
-                        qq{{"code":"$error","error":"Bad Request"}},
-                },
-                qr/Bad Request/,
-            );
-        };
-    }
-
-    for my $error (
-        'AUTHORIZATION_INVALID', 'LICENSE_KEY_REQUIRED',
-        'USER_ID_REQUIRED'
-    ) {
-        subtest $error => sub {
-            _test_ws_error(
-                $service,
-                {
-                    status_code => '401',
-                    response_content =>
-                        qq{{"code":"$error","error":"Unauthorized"}},
-                },
-                qr/Unauthorized/,
-            );
-        };
-    }
-
-    subtest 'Unsupported Media Type' => sub {
-        _test_ws_error(
-            $service,
-            {
-                status_code     => '415',
-                exception_class => 'WebService::MinFraud::Error::HTTP'
-            },
-            qr/Received a 415 error for/
-        );
-    };
-
-    subtest 'Service Not Available' => sub {
-        _test_ws_error(
-            $service,
-            {
-                status_code     => '500',
-                exception_class => 'WebService::MinFraud::Error::HTTP',
-            },
-            qr/Received a server error/,
-        );
-    };
-};
-
 for my $service ( 'factors', 'insights', 'score' ) {
     subtest $service => sub {
         subtest 'test simple success' => sub {
@@ -255,6 +184,86 @@ for my $param (qw(account_id user_id)) {
     };
 }
 
+subtest 'chargeback' => sub {
+    my $service = 'chargeback';
+    subtest 'test simple success' => sub {
+        my $model = _run_request(
+            $service, {
+                status_code    => '204',
+                status_message => 'No Content',
+                requests       => { ip_address => '24.24.24.24' },
+            }
+        );
+
+        isa_ok(
+            $model, 'WebService::MinFraud::Model::Chargeback',
+            'expected class type'
+        );
+    };
+
+    for my $error (
+        'FRAUD_SCORE_INVALID', 'JSON_INVALID',
+        'MAXMIND_ID_INVALID',  'MINFRAUD_ID_INVALID',
+        'PARAMETER_UNKNOWN',   'IP_ADDRESS_INVALID',
+        'IP_ADDRESS_REQUIRED', 'IP_ADDRESS_RESERVED'
+    ) {
+        subtest $error => sub {
+            _test_ws_error(
+                $service,
+                {
+                    status_code => '400',
+                    requests    => { ip_address => '24.24.24.24' },
+                    response_content =>
+                        qq{{"code":"$error","error":"Bad Request"}},
+                },
+                qr/Bad Request/,
+            );
+        };
+    }
+
+    for my $error (
+        'AUTHORIZATION_INVALID', 'LICENSE_KEY_REQUIRED',
+        'USER_ID_REQUIRED'
+    ) {
+        subtest $error => sub {
+            _test_ws_error(
+                $service,
+                {
+                    status_code => '401',
+                    requests    => { ip_address => '24.24.24.24' },
+                    response_content =>
+                        qq{{"code":"$error","error":"Unauthorized"}},
+                },
+                qr/Unauthorized/,
+            );
+        };
+    }
+
+    subtest 'Unsupported Media Type' => sub {
+        _test_ws_error(
+            $service,
+            {
+                status_code     => '415',
+                requests        => { ip_address => '24.24.24.24' },
+                exception_class => 'WebService::MinFraud::Error::HTTP',
+            },
+            qr/Received a 415 error for/
+        );
+    };
+
+    subtest 'Service Not Available' => sub {
+        _test_ws_error(
+            $service,
+            {
+                status_code     => '500',
+                requests        => { ip_address => '24.24.24.24' },
+                exception_class => 'WebService::MinFraud::Error::HTTP',
+            },
+            qr/Received a server error/,
+        );
+    };
+};
+
 done_testing();
 
 sub _test_ws_error {
@@ -262,17 +271,9 @@ sub _test_ws_error {
     my $args             = shift;
     my $expected_message = shift;
 
-    my $exception;
-    if ( $service eq 'chargeback' ) {
-        $exception = exception {
-            _run_chargeback_request($args)
-        };
-    }
-    else {
-        $exception = exception {
-            _run_request( $service, $args )
-        };
-    }
+    my $exception = exception {
+        _run_request( $service, $args )
+    };
 
     isa_ok(
         $exception,
@@ -293,18 +294,16 @@ sub _run_request {
     my $request
         = $args->{requests} || { device => { ip_address => '1.1.1.1' } };
 
+    my $service_info = _get_service_info($service);
+
     my $ua = Test::LWP::UserAgent->new;
     $ua->map_response(
-        sub { $_[0]->uri eq _uri_for($service) },
+        sub { $_[0]->uri eq $service_info->{url} },
         HTTP::Response->new(
-            $args->{status_code} || '200',
-            'OK',
-            [
-                'Content-Type' =>
-                    "application/vnd.maxmind.com-minfraud-${service}+json; charset=UTF-8; version=2.0"
-            ],
-            $args->{response_content}
-                || read_data_file("${service}-response.json"),
+            $args->{status_code}    || '200',
+            $args->{status_message} || 'OK',
+            [ 'Content-Type' => $service_info->{content_type} ],
+            $args->{response_content} || $service_info->{response_content}
         )
     );
 
@@ -314,6 +313,40 @@ sub _run_request {
         ua          => $ua,
         %{ $args->{client_args} || {} }
     )->$service($request);
+}
+
+sub _get_service_info {
+    my $service = shift;
+
+    my $service_lookup = {
+        chargeback => {
+            url => 'https://minfraud.maxmind.com/minfraud/chargeback',
+            content_type     => 'application/json',
+            response_content => undef,
+        },
+        score => {
+            url => _uri_for('score'),
+            content_type =>
+                'application/vnd.maxmind.com-minfraud-score+json; charset=UTF-8; version=2.0',
+            response_content => read_data_file('score-response.json'),
+
+        },
+        insights => {
+            url => _uri_for('insights'),
+            content_type =>
+                'application/vnd.maxmind.com-minfraud-insights+json; charset=UTF-8; version=2.0',
+            response_content => read_data_file('insights-response.json'),
+
+        },
+        factors => {
+            url => _uri_for('factors'),
+            content_type =>
+                'application/vnd.maxmind.com-minfraud-factors+json; charset=UTF-8; version=2.0',
+            response_content => read_data_file('factors-response.json'),
+        },
+    };
+
+    return $service_lookup->{$service};
 }
 
 sub _run_chargeback_request {

--- a/t/WebService/MinFraud/Model/Chargeback.t
+++ b/t/WebService/MinFraud/Model/Chargeback.t
@@ -1,0 +1,14 @@
+use strict;
+use warnings;
+
+use Test::More 0.88;
+use WebService::MinFraud::Model::Chargeback;
+
+subtest 'Can created a chargeback object' => sub {
+    my $class = 'WebService::MinFraud::Model::Chargeback';
+    my $model = $class->new;
+
+    isa_ok( $model, $class );
+};
+
+done_testing;

--- a/t/WebService/MinFraud/Model/Chargeback.t
+++ b/t/WebService/MinFraud/Model/Chargeback.t
@@ -4,7 +4,7 @@ use warnings;
 use Test::More 0.88;
 use WebService::MinFraud::Model::Chargeback;
 
-subtest 'Can created a chargeback object' => sub {
+subtest 'Can create a chargeback object' => sub {
     my $class = 'WebService::MinFraud::Model::Chargeback';
     my $model = $class->new;
 

--- a/xt/author-basic.t
+++ b/xt/author-basic.t
@@ -93,7 +93,7 @@ like(
         );
         $test_client->score($request);
     },
-    qr/Invalid account_id or license_key provided/,
+    qr/Your user ID or license key could not be authenticated/,
     'bad account_id throws an exception'
 );
 

--- a/xt/author-basic.t
+++ b/xt/author-basic.t
@@ -75,6 +75,11 @@ subtest 'factors' => sub {
     }
 };
 
+subtest 'chargeback' => sub {
+    my $response = $client->chargeback( { ip_address => '1.2.3.4' } );
+    isa_ok( $response, 'WebService::MinFraud::Model::Chargeback' );
+};
+
 like(
     exception {
 


### PR DESCRIPTION
I was needing access to the chargeback api as well as the fraud service api. I noticed that this was discussed previously in #18 and that a pull request for such a feature would be welcomed. 

I've made several changes to bring in chargeback support. I've broken out the Validation functionality to be more polymorphic and I've added a model for chargeback to conform with the existing behavior.

Additionally, I have fixed a couple bugs. One in xt/author-basic.t to check for the correct exception message on user id failure and a autovivification bug in WebService::MinFraud::Client->_fix_booleans. 